### PR TITLE
Allow loading dumped fingerprints

### DIFF
--- a/fingerprint.cc
+++ b/fingerprint.cc
@@ -23,6 +23,22 @@ Napi::Object Fingerprint::Init(Napi::Env env, Napi::Object exports) {
   return exports;
 }
 
+Fingerprint::Fingerprint(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Fingerprint>(info) {
+  if (info.Length() == 0) {
+    return;
+  }
+
+  if (!info[0].IsBuffer()) {
+    Napi::Error::New(info.Env(), "Invalid arguments").ThrowAsJavaScriptException();
+    return;
+  }
+
+  auto arg = info[0].As<Napi::Uint8Array>();
+  std::string buf(reinterpret_cast<char*>(arg.Data()), arg.ByteLength());
+
+  set_bytes(std::move(buf));
+}
+
 Napi::Value Fingerprint::Dump(const Napi::CallbackInfo& info) {
   return Napi::Buffer<char>::New(info.Env(), bytes_.data(), bytes_.size());
 }

--- a/fingerprint.h
+++ b/fingerprint.h
@@ -13,7 +13,7 @@ class Fingerprint final : public Napi::ObjectWrap<Fingerprint> {
  public:
   static Napi::Value New(Napi::Env env, std::string bytes);
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
-  Fingerprint(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Fingerprint>(info) {}
+  Fingerprint(const Napi::CallbackInfo& info);
 
   const std::string& bytes() const { return bytes_; }
   void set_bytes(std::string bytes) { bytes_ = std::move(bytes); };


### PR DESCRIPTION
It was possible to call `let buf = ft.dump()` to get the fingerprint as a buffer but it wasn't possible to use that buffer to make a lookup. With this change you can now call `let ft = new Fingerprint(buf)` to load the dumped fingerprint.