### PR TITLE
Fix problem with spaces in path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,7 @@
         "mock.cc"
       ],
       "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")",
+        "<!@(node -p \"require('node-addon-api').include.replace(' ', '\\\\\\ ')\")",
       ],
       "libraries": [
         "-Wl,-rpath,/usr/local/lib",


### PR DESCRIPTION
If there's a space in the build path, gyp got confused and failed to build, leading to an error like

    fatal error: 'napi.h' file not found

This PR should fix the issue.