### PR TITLE
Added error.is_retryable and RESOURCE_EXHAUSTED

### DIFF
--- a/baseworker.cc
+++ b/baseworker.cc
@@ -4,12 +4,13 @@
 #include "error.h"
 
 void BaseWorker::Fail(const Pex_Status* status) {
-  Fail(Pex_Status_GetCode(status), Pex_Status_GetMessage(status));
+  Fail(Pex_Status_GetCode(status), Pex_Status_GetMessage(status), Pex_Status_IsRetryable(status));
 }
 
-void BaseWorker::Fail(int code, const std::string& message) {
+void BaseWorker::Fail(int code, const std::string& message, bool is_retryable) {
   status_code_ = code;
   status_message_ = message;
+  is_retryable_ = is_retryable;
 }
 
 bool BaseWorker::Failed() {
@@ -43,7 +44,7 @@ void BaseWorker::OnError(const Napi::Error& error) {
 }
 
 void BaseWorker::Reject() {
-  auto err = Error::New(Env(), status_code_, status_message_);
+  auto err = Error::New(Env(), status_code_, status_message_, is_retryable_);
   deferred_.Reject(err);
 }
 

--- a/baseworker.h
+++ b/baseworker.h
@@ -16,7 +16,7 @@ class BaseWorker : public Napi::AsyncWorker {
   virtual Napi::Value Resolve() = 0;
 
   void Fail(const Pex_Status* status);
-  void Fail(int code, const std::string& msg);
+  void Fail(int code, const std::string& msg, bool is_retryable = false);
   bool Failed();
 
   void OOM();
@@ -29,6 +29,7 @@ class BaseWorker : public Napi::AsyncWorker {
   Napi::Promise::Deferred deferred_;
   int status_code_ = 0;
   std::string status_message_;
+  bool is_retryable_ = false;
 };
 
 #endif  // _BASEWORKER_H_

--- a/error.cc
+++ b/error.cc
@@ -4,11 +4,12 @@
 
 #include "context.h"
 
-Napi::Value Error::New(Napi::Env env, int code, std::string message) {
+Napi::Value Error::New(Napi::Env env, int code, std::string message, bool is_retryable) {
   auto ctx = env.GetInstanceData<Context>();
   auto err = ctx->error.New({});
   err.Set("code", code);
   err.Set("message", message);
+  err.Set("is_retryable", is_retryable);
   err.Freeze();
   return err;
 }
@@ -28,6 +29,7 @@ Napi::Object Error::Init(Napi::Env env, Napi::Object exports) {
           StaticValue("CONNECTION_ERROR", Napi::Number::New(env, ErrorCode::CONNECTION_ERROR)),
           StaticValue("LOOKUP_FAILED", Napi::Number::New(env, ErrorCode::LOOKUP_FAILED)),
           StaticValue("LOOKUP_TIMED_OUT", Napi::Number::New(env, ErrorCode::LOOKUP_TIMED_OUT)),
+          StaticValue("RESOURCE_EXHAUSTED", Napi::Number::New(env, ErrorCode::RESOURCE_EXHAUSTED)),
       });
 
   auto ctx = env.GetInstanceData<Context>();

--- a/error.h
+++ b/error.h
@@ -17,12 +17,13 @@ enum ErrorCode {
   NOT_INITIALIZED = 8,
   CONNECTION_ERROR = 9,
   LOOKUP_FAILED = 10,
-  LOOKUP_TIMED_OUT = 11
+  LOOKUP_TIMED_OUT = 11,
+  RESOURCE_EXHAUSTED = 12
 };
 
 class Error : public Napi::ObjectWrap<Error> {
  public:
-  static Napi::Value New(Napi::Env env, int code, std::string message);
+  static Napi::Value New(Napi::Env env, int code, std::string message, bool is_retryable = false);
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
   Error(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Error>(info) {}


### PR DESCRIPTION
The `error.is_retryable` will tell the user whether retrying this error might resolve the issue.

`RESOURCE_EXHAUSTED` error will be retruned when a user sends more requests that is allowed by their quota.